### PR TITLE
Fix rerun-if-changed behaviour in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,11 +3,10 @@ extern crate prost_build;
 use std::path::PathBuf;
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=*.proto");
+    let blizzard_proto_path = PathBuf::from("src").join("blizzard").join("proto");
+    println!("cargo:rerun-if-changed={}", blizzard_proto_path.to_string_lossy());
 
     println!("Compiling protos...");
-    let blizzard_proto_path = PathBuf::from("src").join("blizzard").join("proto");
     prost_build::Config::new()
         .out_dir(&blizzard_proto_path)
         .compile_protos(


### PR DESCRIPTION
## Description

I am using this library for a project and noticed that the build script was always running, resulting in a noticeable hit to compile-time. After investigating, I realised that the `rerun-if-changed` lines in the build script didn't do the right thing (they have to be paths to files or directories, wildcards don't work).

I've fixed this by changing it to only build when the relevant proto folder is updated. I've tested this behaviour locally by editing the Protodef files and can confirm it works as expected.

I did not open an issue for this because it is a very minor fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
